### PR TITLE
Make the heatmap package releaseable to ros.org buildfarm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+# This config file for Travis CI utilizes industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required
+services:
+  - docker
+language: generic
+compiler:
+  - gcc
+env:
+  matrix:
+    - ROS_DISTRO="indigo"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="indigo"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu USE_DEB=true DEBUG_BASH=true
+    - ROS_DISTRO="indigo"  PRERELEASE=true
+    - ROS_DISTRO="jade"     ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu DEBUG_BASH=true
+    - ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu USE_DEB=true DEBUG_BASH=true    
+    - ROS_DISTRO="kinetic"  PRERELEASE=true
+    - ROS_DISTRO="lunar"    ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="indigo"  PRERELEASE=true
+    - env: ROS_DISTRO="jade"     ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: ROS_DISTRO="kinetic"  PRERELEASE=true
+    - env: ROS_DISTRO="lunar"    ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  - .ci_config/travis.sh

--- a/README.md
+++ b/README.md
@@ -7,9 +7,3 @@ For coverage path planning it uses the "Moe the autonomous lawnmower" planner:
 https://github.com/Auburn-Automow/au_automow_common
 
 It also uses the RViz point to polygon user interface from the frontier_exploration package by Paul Bovbel:    https://github.com/paulbovbel/frontier_exploration  
-  
-## Installation  
-The path planner depends on the "shapely" python module.  
-Learn how to install it here:  
-https://pypi.python.org/pypi/Shapely  
-

--- a/package.xml
+++ b/package.xml
@@ -56,6 +56,7 @@
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>move_base_msgs</run_depend>
+  <run_depend>python-shapely</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -42,25 +42,24 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>actionlib</build_depend>
+  <build_depend>costmap_2d</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>move_base_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
   <build_depend>visualization_msgs</build_depend>
-  <build_depend>move_base_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>costmap_2d</build_depend>
+  <run_depend>actionlib</run_depend>
+  <run_depend>costmap_2d</run_depend>
+  <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>move_base_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>visualization_msgs</run_depend>
-  <run_depend>move_base_msgs</run_depend>
-  <run_depend>actionlib</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>costmap_2d</run_depend>
-
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
1st, thanks for a nice package!

I saw this package used to be released into ROS buildfarm (e.g. https://github.com/ros/rosdistro/pull/9324) and met an issue there (e.g. https://github.com/eybee/heatmap/issues/1). But along with this PR, I [ran some CI jobs](https://travis-ci.org/130s/heatmap/builds/309502560) incl. [ROS prerelease test (on Kinetic)](https://travis-ci.org/130s/heatmap/jobs/309502567) on my fork and they are all green for ROS Jade, Kinetic, Lunar.

So, why don't we?

If you need a help for making a release I'm happy to help.